### PR TITLE
fix(cicd): correct base url

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -39,7 +39,7 @@ jobs:
             - name: Build WASM Demo
               run: |
                   cd crates/primitives/examples/wasm-demo
-                  trunk build --release
+                  trunk build --release --public-url /nectar/
 
             - name: Deploy to GitHub Pages
               uses: JamesIves/github-pages-deploy-action@v4


### PR DESCRIPTION
This PR:

1. Fixes the base URL to make the examples work with github pages.